### PR TITLE
Update Dependencies and Use Less Buckets for Tests

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -334,7 +334,7 @@
      * @returns {Promise|*} Returns a `Promise` if a callback is not provided
      */
     S3fs.prototype.headObject = function (path, cb) {
-    //TODO: Convert the rest of the code to using this method for retrieving the head.
+        //TODO: Convert the rest of the code to using this method for retrieving the head.
         var deferred = !cb ? q.defer() : undefined;
         this.s3.headObject({
             Bucket: this.bucket,
@@ -553,12 +553,12 @@
                     return !directoryRegExp.test(object);
                 }).map(function (object) {
                     //remove all the items
-                    return self.unlink((path ? self.path + s3Utils.toKey(path) + '/' : '') + object);
+                    return self.unlink((path ? s3Utils.toKey(path) + '/' : '') + object);
                 }).concat(objects.filter(function (object) {
                     return directoryRegExp.test(object);
                 }).map(function (object) {
                     //remove all folders
-                    return self.rmdir((path ? self.path + s3Utils.toKey(path) + '/' : '') + object);
+                    return self.rmdir((path ? s3Utils.toKey(path) + '/' : '') + object);
                 })));
             });
 
@@ -666,7 +666,16 @@
             if (err) {
                 return deferred.reject(err);
             }
-            var contentsList = data.Contents;
+            var contentsList = data.Contents.map(function (item) {
+                if (objectPrefix && item && item.Key && item.Key.indexOf(objectPrefix) === 0) {
+                    item.Key = item.Key.replace(objectPrefix, '');
+                }
+
+                return item;
+            }).filter(function(item) {
+                return item && item.Key;
+            });
+
             if (data.IsTruncated) {
                 return listAllObjects(s3, bucket, prefix, delimiter, data.KeyMarker).then(function (contents) {
                     return deferred.resolve(contentsList.concat(contents));

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -672,7 +672,7 @@
                 }
 
                 return item;
-            }).filter(function(item) {
+            }).filter(function (item) {
                 return item && item.Key;
             });
 

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   "main": "index.js",
   "dependencies": {
     "aws-sdk": "^2.x",
-    "cb-q": "0.0.2",
+    "cb-q": "^0.x",
     "extend": "^2.x",
     "q": "^1.x"
   },
   "devDependencies": {
     "buddy.js": "^0.x",
-    "chai": "<1.10",
+    "chai": "^2.x",
     "chai-as-promised": "^4.x",
     "dirty-chai": "^1.x",
     "nsp": "^1.x",
@@ -55,8 +55,7 @@
     "jscs": "^1.x",
     "jshint": "^2.x",
     "jsinspect": "^0.x",
-    "reporter-file": "^0.x",
-    "should": "^4.x"
+    "reporter-file": "^0.x"
   },
   "scripts": {
     "test": "MOCHA_REPORTER=Spec MOCHA_REPORTER_FILE=reports/xunit.xml istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks  --timeout 60000 --reporter reporter-file test/ && jshint --show-non-errors . && jscs . && buddy index.js lib test && nsp audit-package",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jscs": "^1.x",
     "jshint": "^2.x",
     "jsinspect": "^0.x",
-    "reporter-file": "^0.x"
+    "reporter-file": "^1.x"
   },
   "scripts": {
     "test": "MOCHA_REPORTER=Spec MOCHA_REPORTER_FILE=reports/xunit.xml istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks  --timeout 60000 --reporter reporter-file test/ && jshint --show-non-errors . && jscs . && buddy index.js lib test && nsp audit-package",

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -45,7 +45,7 @@
                 secretAccessKey: process.env.AWS_SECRET_KEY,
                 region: process.env.AWS_REGION
             };
-            bucketName = 's3fs-test-bucket-' + (Math.random() + '').slice(2, 8);
+            bucketName = 's3fs-bucket-test-bucket-' + (Math.random() + '').slice(2, 8);
             s3fsImpl = new S3FS(s3Credentials, bucketName);
         });
 
@@ -63,7 +63,7 @@
         });
 
         it('should be able to create a new bucket', function () {
-            return expect(s3fsImpl.create()).to.eventually.be.fulfilled;
+            return expect(s3fsImpl.create()).to.eventually.be.fulfilled();
         });
 
         it('shouldn\'t received an error when creating a duplicate bucket owned by the same account', function () {
@@ -71,7 +71,7 @@
                     .then(function () {
                         return s3fsImpl.create();
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it.skip('shouldn\'t be able to create a bucket with an invalid name', function () {
@@ -83,19 +83,19 @@
         });
 
         it('should be able to create a new bucket with options', function () {
-            return expect(s3fsImpl.create({})).to.eventually.be.fulfilled;
+            return expect(s3fsImpl.create({})).to.eventually.be.fulfilled();
         });
 
         it('should be able to create a new bucket with a callback', function () {
             var cb = cbQ.cb();
             s3fsImpl.create(cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to create a new bucket with options and a callback', function () {
             var cb = cbQ.cb();
             s3fsImpl.create({}, cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to delete a bucket', function () {
@@ -103,7 +103,7 @@
                     .then(function () {
                         return s3fsImpl.delete();
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to delete a bucket with a callback', function () {
@@ -113,7 +113,7 @@
                         s3fsImpl.delete(cb);
                         return cb.promise;
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('shouldn\'t be able to delete a bucket with contents', function () {
@@ -142,7 +142,7 @@
             return expect(s3fsImpl.create()
                 .then(function () {
                     return s3fsImpl.destroy();
-                })).to.eventually.be.fulfilled;
+                })).to.eventually.be.fulfilled();
         });
 
         it('should be able to destroy bucket with a callback', function () {
@@ -151,7 +151,7 @@
                     var cb = cbQ.cb();
                     s3fsImpl.destroy(cb);
                     return cb.promise;
-                })).to.eventually.be.fulfilled;
+                })).to.eventually.be.fulfilled();
         });
 
         it('should be able to list all the files in a bucket', function () {
@@ -175,7 +175,7 @@
                         return s3fsImpl.readdir('/');
                     })
             ).to.eventually.satisfy(function (files) {
-                    expect(files).to.have.length(2);
+                    expect(files).to.have.lengthOf(2);
                     expect(files[0]).to.equal('testDir/');
                     expect(files[1]).to.equal('testDirDos/');
                     return true;
@@ -205,7 +205,7 @@
                         return cb.promise;
                     })
             ).to.eventually.satisfy(function (files) {
-                    expect(files).to.have.length(2);
+                    expect(files).to.have.lengthOf(2);
                     expect(files[0]).to.equal('testDir/');
                     expect(files[1]).to.equal('testDirDos/');
                     return true;

--- a/test/file.js
+++ b/test/file.js
@@ -82,8 +82,8 @@
         });
 
         it('should be able to write a large file with a callback', function () {
-            var largeFile = fs.readFileSync('./test/mock/large-file.txt');
-            var cb = cbQ.cb();
+            var largeFile = fs.readFileSync('./test/mock/large-file.txt'),
+                cb = cbQ.cb();
             bucketS3fsImpl.writeFile('write-large-callback.txt', largeFile, cb);
             return expect(cb.promise).to.eventually.be.fulfilled();
         });
@@ -179,8 +179,8 @@
         });
 
         it('should be able to write a file from a buffer with a callback', function () {
-            var exampleFile = fs.readFileSync('./test/mock/example-file.json');
-            var cb = cbQ.cb();
+            var exampleFile = fs.readFileSync('./test/mock/example-file.json'),
+                cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-buffer-callback.json', exampleFile, cb);
             return expect(cb.promise).to.eventually.be.fulfilled();
         });
@@ -191,8 +191,8 @@
         });
 
         it('should be able to write a file from a stream with a callback', function () {
-            var stream = fs.createReadStream('./test/mock/example-file.json');
-            var cb = cbQ.cb();
+            var stream = fs.createReadStream('./test/mock/example-file.json'),
+                cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-stream-callback.json', stream, cb);
             return expect(cb.promise).to.eventually.be.fulfilled();
         });
@@ -203,8 +203,8 @@
         });
 
         it('should be able to write a large file from a stream with a callback', function () {
-            var stream = fs.createReadStream('./test/mock/large-file.txt');
-            var cb = cbQ.cb();
+            var stream = fs.createReadStream('./test/mock/large-file.txt'),
+                cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-large-stream-callback.txt', stream, cb);
             return expect(cb.promise).to.eventually.be.fulfilled();
         });

--- a/test/file.js
+++ b/test/file.js
@@ -31,25 +31,29 @@
     describe('S3FS Files', function () {
         var s3Credentials,
             bucketName,
+            bucketS3fsImpl,
             s3fsImpl;
 
         before(function () {
             if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_KEY) {
                 throw new Error('Both an AWS Access Key ID and Secret Key are required');
             }
-        });
-
-        beforeEach(function () {
             s3Credentials = {
                 accessKeyId: process.env.AWS_ACCESS_KEY_ID,
                 secretAccessKey: process.env.AWS_SECRET_KEY,
                 region: process.env.AWS_REGION
             };
-            bucketName = 's3fs-test-bucket-' + (Math.random() + '').slice(2, 8);
+            bucketName = 's3fs-file-test-bucket-' + (Math.random() + '').slice(2, 8);
             s3fsImpl = new S3FS(s3Credentials, bucketName);
+
+            return s3fsImpl.create();
         });
 
-        afterEach(function (done) {
+        beforeEach(function () {
+            bucketS3fsImpl = s3fsImpl.clone('testDir-' + (Math.random() + '').slice(2, 8));
+        });
+
+        after(function (done) {
             s3fsImpl.destroy().then(function () {
                 done();
             }, function (reason) {
@@ -63,131 +67,41 @@
         });
 
         it('should be able to write a file from a string', function () {
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                })).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }')).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a file from a string with a callback', function () {
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', '{ "test": "test" }', cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('test.json', '{ "test": "test" }', cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a large file', function () {
             var largeFile = fs.readFileSync('./test/mock/large-file.txt');
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', largeFile);
-                })).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('write-large.txt', largeFile)).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a large file with a callback', function () {
             var largeFile = fs.readFileSync('./test/mock/large-file.txt');
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', largeFile, cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('write-large-callback.txt', largeFile, cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to tell if a file exists', function () {
-            return expect(s3fsImpl.create()
+            return expect(bucketS3fsImpl.writeFile('test-exists.json', '{ "test": "test" }')
                     .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
-                    .then(function () {
-                        return s3fsImpl.exists('test-file.json');
-                    })
-            ).to.eventually.be.fulfilled;
-        });
-
-        it('should be able to copy an object', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{}');
-                    })
-                    .then(function () {
-                        return s3fsImpl.copyObject('test-file.json', 'test-file-dos.json');
-                    })
-            ).to.eventually.be.fulfilled;
-        });
-
-        it('should be able to copy an object with a callback', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{}');
-                    })
-                    .then(function () {
-                        var cb = cbQ.cb();
-                        s3fsImpl.copyObject('test-file.json', 'test-file-dos.json', cb);
-                        return cb.promise;
-                    })
-            ).to.eventually.be.fulfilled;
-        });
-
-        it('should be able to get the head of an object', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{}');
-                    })
-                    .then(function () {
-                        return s3fsImpl.headObject('test-file.json');
-                    })
-            ).to.eventually.be.fulfilled;
-        });
-
-        it('should be able to get the head of an object with a callback', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{}');
-                    })
-                    .then(function () {
-                        var cb = cbQ.cb();
-                        s3fsImpl.headObject('test-file.json', cb);
-                        return cb.promise;
-                    })
-            ).to.eventually.be.fulfilled;
-        });
-
-        it('should be able to delete a file', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
-                    .then(function () {
-                        return s3fsImpl.unlink('test-file.json');
-                    })
-            ).to.eventually.be.fulfilled;
-        });
-
-        it('should be able to delete a file with a callback', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
-                    .then(function () {
-                        var cb = cbQ.cb();
-                        s3fsImpl.unlink('test-file.json', cb);
-                        return cb.promise;
+                        return bucketS3fsImpl.exists('test-exists.json');
                     })
             ).to.eventually.be.fulfilled;
         });
 
         it('should be able to tell if a file exists with a callback', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
+            return expect(bucketS3fsImpl.writeFile('test-exists-callback.json', '{ "test": "test" }')
                     .then(function () {
                         //Cannot use cbQ here since it is not the standard err, data callback signature.
                         var deferred = Q.defer();
-                        s3fsImpl.exists('test-file.json', function (exists) {
+                        bucketS3fsImpl.exists('test-exists-callback.json', function (exists) {
                             deferred.resolve(exists);
                         });
                         return deferred.promise;
@@ -195,158 +109,163 @@
             ).to.eventually.be.equal(true);
         });
 
+        it('should be able to copy an object', function () {
+            return expect(bucketS3fsImpl.writeFile('test-copy.json', '{}')
+                    .then(function () {
+                        return bucketS3fsImpl.copyObject('test-copy.json', 'test-copy-dos.json');
+                    })
+            ).to.eventually.be.fulfilled;
+        });
+
+        it('should be able to copy an object with a callback', function () {
+            return expect(bucketS3fsImpl.writeFile('test-copy-callback.json', '{}')
+                    .then(function () {
+                        var cb = cbQ.cb();
+                        bucketS3fsImpl.copyObject('test-copy-callback.json', 'test-copy-callback-dos.json', cb);
+                        return cb.promise;
+                    })
+            ).to.eventually.be.fulfilled;
+        });
+
+        it('should be able to get the head of an object', function () {
+            return expect(bucketS3fsImpl.writeFile('test-head.json', '{}')
+                    .then(function () {
+                        return bucketS3fsImpl.headObject('test-head.json');
+                    })
+            ).to.eventually.be.fulfilled;
+        });
+
+        it('should be able to get the head of an object with a callback', function () {
+            return expect(bucketS3fsImpl.writeFile('test-head-callback.json', '{}')
+                    .then(function () {
+                        var cb = cbQ.cb();
+                        bucketS3fsImpl.headObject('test-head-callback.json', cb);
+                        return cb.promise;
+                    })
+            ).to.eventually.be.fulfilled;
+        });
+
+        it('should be able to delete a file', function () {
+            return expect(bucketS3fsImpl.writeFile('test-delete.json', '{ "test": "test" }')
+                    .then(function () {
+                        return bucketS3fsImpl.unlink('test-delete.json');
+                    })
+            ).to.eventually.be.fulfilled;
+        });
+
+        it('should be able to delete a file with a callback', function () {
+            return expect(bucketS3fsImpl.writeFile('test-delete-callback.json', '{ "test": "test" }')
+                    .then(function () {
+                        var cb = cbQ.cb();
+                        bucketS3fsImpl.unlink('test-delete-callback.json', cb);
+                        return cb.promise;
+                    })
+            ).to.eventually.be.fulfilled;
+        });
+
         it('shouldn\'t be able to write a file from an object', function () {
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', {test: 'test'});
-                })).to.eventually.be.rejectedWith('Expected params.Body to be a string, Buffer, Stream, Blob, or typed array object');
+            return expect(bucketS3fsImpl.writeFile('test-write-object.json', {test: 'test'})).to.eventually.be.rejectedWith('Expected params.Body to be a string, Buffer, Stream, Blob, or typed array object');
         });
 
         it('shouldn\'t be able to write a file from an object with a callback', function () {
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', {test: 'test'}, cb);
-                    return cb.promise;
-                })).to.eventually.be.rejectedWith('Expected params.Body to be a string, Buffer, Stream, Blob, or typed array object');
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('test-write-object.json', {test: 'test'}, cb);
+            return expect(cb.promise).to.eventually.be.rejectedWith('Expected params.Body to be a string, Buffer, Stream, Blob, or typed array object');
         });
 
         it('should be able to write a file from a buffer', function () {
-            var exampleFile = fs.readFileSync('./test/mock/large-file.txt');
-
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', exampleFile);
-                })).to.eventually.be.fulfilled;
+            var exampleFile = fs.readFileSync('./test/mock/example-file.json');
+            return expect(bucketS3fsImpl.writeFile('test-buffer.json', exampleFile)).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a file from a buffer with a callback', function () {
-            var exampleFile = fs.readFileSync('./test/mock/large-file.txt');
-
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', exampleFile, cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            var exampleFile = fs.readFileSync('./test/mock/example-file.json');
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('test-buffer-callback.json', exampleFile, cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a file from a stream', function () {
             var stream = fs.createReadStream('./test/mock/example-file.json');
-
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', stream);
-                })).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-stream.json', stream)).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a file from a stream with a callback', function () {
             var stream = fs.createReadStream('./test/mock/example-file.json');
-
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', stream, cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('test-stream-callback.json', stream, cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a large file from a stream', function () {
             var stream = fs.createReadStream('./test/mock/large-file.txt');
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', stream);
-                })).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-large-stream.txt', stream)).to.eventually.be.fulfilled;
         });
 
         it('should be able to write a large file from a stream with a callback', function () {
             var stream = fs.createReadStream('./test/mock/large-file.txt');
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', stream, cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('test-large-stream-callback.txt', stream, cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to pipe a file from a stream', function () {
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var deferred = Q.defer();
-                    fs.createReadStream('./test/mock/example-file.json')
-                        .pipe(s3fsImpl.createWriteStream('test-file.json'))
-                        .on('finish', function () {
-                            deferred.resolve();
-                        })
-                        .on('error', function (err) {
-                            deferred.reject(err);
-                        });
-                    return deferred.promise;
-                })).to.eventually.be.fulfilled;
+            var deferred = Q.defer();
+            fs.createReadStream('./test/mock/example-file.json')
+                .pipe(bucketS3fsImpl.createWriteStream('test-pipe.json'))
+                .on('finish', function () {
+                    deferred.resolve();
+                })
+                .on('error', function (err) {
+                    deferred.reject(err);
+                });
+            return expect(deferred.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to pipe a large file from a stream', function () {
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var deferred = Q.defer();
-                    fs.createReadStream('./test/mock/large-file.txt')
-                        .pipe(s3fsImpl.createWriteStream('test-file.txt'))
-                        .on('finish', function () {
-                            deferred.resolve();
-                        })
-                        .on('error', function (err) {
-                            deferred.reject(err);
-                        });
-                    return deferred.promise;
-                })).to.eventually.be.fulfilled;
+            var deferred = Q.defer();
+            fs.createReadStream('./test/mock/large-file.txt')
+                .pipe(bucketS3fsImpl.createWriteStream('test-pipe-callback.txt'))
+                .on('finish', function () {
+                    deferred.resolve();
+                })
+                .on('error', function (err) {
+                    deferred.reject(err);
+                });
+            return expect(deferred.promise).to.eventually.be.fulfilled;
         });
 
         it.skip('should be able to write a file from a blob', function () {
             //TODO: Get this setup
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', {test: 'test'});
-                })).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-blobl.json', {test: 'test'})).to.eventually.be.fulfilled;
         });
 
         it.skip('should be able to write a file from a blob with a callback', function () {
             //TODO: Get this setup
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', {test: 'test'}, cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('test-blob-callback.json', {test: 'test'}, cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it.skip('should be able to write a file from a typed array', function () {
             //TODO: Get this setup
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.writeFile('test-file.json', {test: 'test'});
-                })).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-typed.json', {test: 'test'})).to.eventually.be.fulfilled;
         });
 
         it.skip('should be able to write a file from a typed array with a callback', function () {
             //TODO: Get this setup
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.writeFile('test-file.json', {test: 'test'}, cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            var cb = cbQ.cb();
+            bucketS3fsImpl.writeFile('test-typed-callback.json', {test: 'test'}, cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to read the file as a stream', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
+            return expect(bucketS3fsImpl.writeFile('test-read-stream.json', '{ "test": "test" }')
                     .then(function () {
                         var deferred = Q.defer(),
                             data = '';
                         try {
-                            s3fsImpl.createReadStream('test-file.json')
+                            bucketS3fsImpl.createReadStream('test-read-stream.json')
                                 .on('data', function (chunk) {
                                     data += chunk;
                                 })
@@ -366,12 +285,9 @@
         });
 
         it('should be able to retrieve the stats of a file - stat(2)', function () {
-            return expect(s3fsImpl.create()
+            return expect(bucketS3fsImpl.writeFile('test-stat.json', '{ "test": "test" }')
                     .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
-                    .then(function () {
-                        return s3fsImpl.stat('test-file.json');
+                        return bucketS3fsImpl.stat('test-stat.json');
                     })
             ).to.eventually.satisfy(function (stats) {
                     expect(stats.isFile()).to.be.true();
@@ -380,13 +296,10 @@
         });
 
         it('should be able to retrieve the stats of a file with a callback - stat(2)', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
+            return expect(bucketS3fsImpl.writeFile('test-stat-callback.json', '{ "test": "test" }')
                     .then(function () {
                         var cb = cbQ.cb();
-                        s3fsImpl.stat('test-file.json', cb);
+                        bucketS3fsImpl.stat('test-stat-callback.json', cb);
                         return cb.promise;
                     })
             ).to.eventually.satisfy(function (stats) {
@@ -396,36 +309,19 @@
         });
 
         it('shouldn\'t be able to retrieve the stats of a file that doesn\'t exist - stat(2)', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
-                    .then(function () {
-                        return s3fsImpl.stat('test-file-no-exist.json');
-                    })
-            ).to.eventually.be.rejectedWith(Error, 'NotFound');
+            return expect(bucketS3fsImpl.stat('test-file-no-exist.json')).to.eventually.be.rejectedWith(Error, 'NotFound');
         });
 
         it('shouldn\'t be able to retrieve the stats of a file that doesn\'t exist with a callback - stat(2)', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
-                    .then(function () {
-                        var cb = cbQ.cb();
-                        s3fsImpl.stat('test-file-no-exist.json', cb);
-                        return cb.promise;
-                    })
-            ).to.eventually.be.rejectedWith(Error, 'NotFound');
+            var cb = cbQ.cb();
+            bucketS3fsImpl.stat('test-file-no-exist.json', cb);
+            return expect(cb.promise).to.eventually.be.rejectedWith(Error, 'NotFound');
         });
 
         it('should be able to retrieve the stats of a file - lstat(2)', function () {
-            return expect(s3fsImpl.create()
+            return expect(bucketS3fsImpl.writeFile('test-lstat.json', '{ "test": "test" }')
                     .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
-                    .then(function () {
-                        return s3fsImpl.lstat('test-file.json');
+                        return bucketS3fsImpl.lstat('test-lstat.json');
                     })
             ).to.eventually.satisfy(function (stats) {
                     expect(stats.isFile()).to.be.true();
@@ -434,13 +330,10 @@
         });
 
         it('should be able to retrieve the stats of a file with a callback - lstat(2)', function () {
-            return expect(s3fsImpl.create()
-                    .then(function () {
-                        return s3fsImpl.writeFile('test-file.json', '{ "test": "test" }');
-                    })
+            return expect(bucketS3fsImpl.writeFile('test-lstat-callback.json', '{ "test": "test" }')
                     .then(function () {
                         var cb = cbQ.cb();
-                        s3fsImpl.lstat('test-file.json', cb);
+                        bucketS3fsImpl.lstat('test-lstat-callback.json', cb);
                         return cb.promise;
                     })
             ).to.eventually.satisfy(function (stats) {

--- a/test/file.js
+++ b/test/file.js
@@ -67,25 +67,25 @@
         });
 
         it('should be able to write a file from a string', function () {
-            return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }')).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }')).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a file from a string with a callback', function () {
             var cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test.json', '{ "test": "test" }', cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a large file', function () {
             var largeFile = fs.readFileSync('./test/mock/large-file.txt');
-            return expect(bucketS3fsImpl.writeFile('write-large.txt', largeFile)).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('write-large.txt', largeFile)).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a large file with a callback', function () {
             var largeFile = fs.readFileSync('./test/mock/large-file.txt');
             var cb = cbQ.cb();
             bucketS3fsImpl.writeFile('write-large-callback.txt', largeFile, cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to tell if a file exists', function () {
@@ -93,7 +93,7 @@
                     .then(function () {
                         return bucketS3fsImpl.exists('test-exists.json');
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to tell if a file exists with a callback', function () {
@@ -114,7 +114,7 @@
                     .then(function () {
                         return bucketS3fsImpl.copyObject('test-copy.json', 'test-copy-dos.json');
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to copy an object with a callback', function () {
@@ -124,7 +124,7 @@
                         bucketS3fsImpl.copyObject('test-copy-callback.json', 'test-copy-callback-dos.json', cb);
                         return cb.promise;
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to get the head of an object', function () {
@@ -132,7 +132,7 @@
                     .then(function () {
                         return bucketS3fsImpl.headObject('test-head.json');
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to get the head of an object with a callback', function () {
@@ -142,7 +142,7 @@
                         bucketS3fsImpl.headObject('test-head-callback.json', cb);
                         return cb.promise;
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to delete a file', function () {
@@ -150,7 +150,7 @@
                     .then(function () {
                         return bucketS3fsImpl.unlink('test-delete.json');
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to delete a file with a callback', function () {
@@ -160,7 +160,7 @@
                         bucketS3fsImpl.unlink('test-delete-callback.json', cb);
                         return cb.promise;
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('shouldn\'t be able to write a file from an object', function () {
@@ -175,38 +175,38 @@
 
         it('should be able to write a file from a buffer', function () {
             var exampleFile = fs.readFileSync('./test/mock/example-file.json');
-            return expect(bucketS3fsImpl.writeFile('test-buffer.json', exampleFile)).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-buffer.json', exampleFile)).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a file from a buffer with a callback', function () {
             var exampleFile = fs.readFileSync('./test/mock/example-file.json');
             var cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-buffer-callback.json', exampleFile, cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a file from a stream', function () {
             var stream = fs.createReadStream('./test/mock/example-file.json');
-            return expect(bucketS3fsImpl.writeFile('test-stream.json', stream)).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-stream.json', stream)).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a file from a stream with a callback', function () {
             var stream = fs.createReadStream('./test/mock/example-file.json');
             var cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-stream-callback.json', stream, cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a large file from a stream', function () {
             var stream = fs.createReadStream('./test/mock/large-file.txt');
-            return expect(bucketS3fsImpl.writeFile('test-large-stream.txt', stream)).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-large-stream.txt', stream)).to.eventually.be.fulfilled();
         });
 
         it('should be able to write a large file from a stream with a callback', function () {
             var stream = fs.createReadStream('./test/mock/large-file.txt');
             var cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-large-stream-callback.txt', stream, cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to pipe a file from a stream', function () {
@@ -219,7 +219,7 @@
                 .on('error', function (err) {
                     deferred.reject(err);
                 });
-            return expect(deferred.promise).to.eventually.be.fulfilled;
+            return expect(deferred.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to pipe a large file from a stream', function () {
@@ -232,31 +232,31 @@
                 .on('error', function (err) {
                     deferred.reject(err);
                 });
-            return expect(deferred.promise).to.eventually.be.fulfilled;
+            return expect(deferred.promise).to.eventually.be.fulfilled();
         });
 
         it.skip('should be able to write a file from a blob', function () {
             //TODO: Get this setup
-            return expect(bucketS3fsImpl.writeFile('test-blobl.json', {test: 'test'})).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-blobl.json', {test: 'test'})).to.eventually.be.fulfilled();
         });
 
         it.skip('should be able to write a file from a blob with a callback', function () {
             //TODO: Get this setup
             var cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-blob-callback.json', {test: 'test'}, cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it.skip('should be able to write a file from a typed array', function () {
             //TODO: Get this setup
-            return expect(bucketS3fsImpl.writeFile('test-typed.json', {test: 'test'})).to.eventually.be.fulfilled;
+            return expect(bucketS3fsImpl.writeFile('test-typed.json', {test: 'test'})).to.eventually.be.fulfilled();
         });
 
         it.skip('should be able to write a file from a typed array with a callback', function () {
             //TODO: Get this setup
             var cb = cbQ.cb();
             bucketS3fsImpl.writeFile('test-typed-callback.json', {test: 'test'}, cb);
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to read the file as a stream', function () {
@@ -281,7 +281,7 @@
                         }
                         return deferred.promise;
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to retrieve the stats of a file - stat(2)', function () {

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -73,7 +73,7 @@
             return expect(
                 bucketS3fsImpl.putBucketLifecycle('test-lifecycle', prefix, days)
                 //TODO: Add verification that the lifecycle was set
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to set a bucket lifecycle with a callback', function () {
@@ -83,7 +83,7 @@
             var cb = cbQ.cb();
             bucketS3fsImpl.putBucketLifecycle('test-lifecycle-callback', prefix, days, cb);
             //TODO: Add verification that the lifecycle was set
-            return expect(cb.promise).to.eventually.be.fulfilled;
+            return expect(cb.promise).to.eventually.be.fulfilled();
         });
 
         it('should be able to update a bucket lifecycle', function () {
@@ -96,7 +96,7 @@
                         return s3fsImpl.putBucketLifecycle('test-lifecycle-update', prefix, finalDays);
                         //TODO: Add verification that the lifecycle was set
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
         it('should be able to update a bucket lifecycle with a callback', function () {
@@ -111,7 +111,7 @@
                         return cb.promise;
                         //TODO: Add verification that the lifecycle was set
                     })
-            ).to.eventually.be.fulfilled;
+            ).to.eventually.be.fulfilled();
         });
 
     });

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -43,7 +43,7 @@
                 secretAccessKey: process.env.AWS_SECRET_KEY,
                 region: process.env.AWS_REGION
             };
-            bucketName = 's3fs-clone-test-bucket-' + (Math.random() + '').slice(2, 8);
+            bucketName = 's3fs-lifecycle-test-bucket-' + (Math.random() + '').slice(2, 8);
             s3fsImpl = new S3FS(s3Credentials, bucketName);
 
             return s3fsImpl.create();
@@ -80,12 +80,10 @@
             var prefix = 'test',
                 days = 1;
 
-            return expect(function () {
-                var cb = cbQ.cb();
-                bucketS3fsImpl.putBucketLifecycle('test-lifecycle-callback', prefix, days, cb);
-                return cb.promise;
-                //TODO: Add verification that the lifecycle was set
-            }).to.eventually.be.fulfilled;
+            var cb = cbQ.cb();
+            bucketS3fsImpl.putBucketLifecycle('test-lifecycle-callback', prefix, days, cb);
+            //TODO: Add verification that the lifecycle was set
+            return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
         it('should be able to update a bucket lifecycle', function () {
@@ -93,13 +91,12 @@
                 initialDays = 1,
                 finalDays = 2;
 
-            return expect(function () {
-                return s3fsImpl.putBucketLifecycle('test-lifecycle-update', prefix, initialDays)
+            return expect(s3fsImpl.putBucketLifecycle('test-lifecycle-update', prefix, initialDays)
                     .then(function () {
                         return s3fsImpl.putBucketLifecycle('test-lifecycle-update', prefix, finalDays);
                         //TODO: Add verification that the lifecycle was set
-                    });
-            }).to.eventually.be.fulfilled;
+                    })
+            ).to.eventually.be.fulfilled;
         });
 
         it('should be able to update a bucket lifecycle with a callback', function () {
@@ -107,15 +104,14 @@
                 initialDays = 1,
                 finalDays = 2;
 
-            return expect(function () {
-                return s3fsImpl.putBucketLifecycle('test-lifecycle-update-callback', prefix, initialDays)
+            return expect(s3fsImpl.putBucketLifecycle('test-lifecycle-update-callback', prefix, initialDays)
                     .then(function () {
                         var cb = cbQ.cb();
                         s3fsImpl.putBucketLifecycle('test-lifecycle-update-callback', prefix, finalDays, cb);
                         return cb.promise;
                         //TODO: Add verification that the lifecycle was set
-                    });
-            }).to.eventually.be.fulfilled;
+                    })
+            ).to.eventually.be.fulfilled;
         });
 
     });

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -78,9 +78,8 @@
 
         it('should be able to set a bucket lifecycle with a callback', function () {
             var prefix = 'test',
-                days = 1;
-
-            var cb = cbQ.cb();
+                days = 1,
+                cb = cbQ.cb();
             bucketS3fsImpl.putBucketLifecycle('test-lifecycle-callback', prefix, days, cb);
             //TODO: Add verification that the lifecycle was set
             return expect(cb.promise).to.eventually.be.fulfilled();

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -31,25 +31,29 @@
     describe('S3FS Bucket Lifecycles', function () {
         var s3Credentials,
             bucketName,
+            bucketS3fsImpl,
             s3fsImpl;
 
         before(function () {
             if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_KEY) {
                 throw new Error('Both an AWS Access Key ID and Secret Key are required');
             }
-        });
-
-        beforeEach(function () {
             s3Credentials = {
                 accessKeyId: process.env.AWS_ACCESS_KEY_ID,
                 secretAccessKey: process.env.AWS_SECRET_KEY,
                 region: process.env.AWS_REGION
             };
-            bucketName = 's3fs-test-bucket-' + (Math.random() + '').slice(2, 8);
+            bucketName = 's3fs-clone-test-bucket-' + (Math.random() + '').slice(2, 8);
             s3fsImpl = new S3FS(s3Credentials, bucketName);
+
+            return s3fsImpl.create();
         });
 
-        afterEach(function (done) {
+        beforeEach(function () {
+            bucketS3fsImpl = s3fsImpl.clone('testDir-' + (Math.random() + '').slice(2, 8));
+        });
+
+        after(function (done) {
             s3fsImpl.destroy().then(function () {
                 done();
             }, function (reason) {
@@ -66,22 +70,22 @@
             var prefix = 'test',
                 days = 1;
 
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.putBucketLifecycle('test-expiration-lifecycle', prefix, days);
-                })).to.eventually.be.fulfilled;
+            return expect(
+                bucketS3fsImpl.putBucketLifecycle('test-lifecycle', prefix, days)
+                //TODO: Add verification that the lifecycle was set
+            ).to.eventually.be.fulfilled;
         });
 
         it('should be able to set a bucket lifecycle with a callback', function () {
             var prefix = 'test',
                 days = 1;
 
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    var cb = cbQ.cb();
-                    s3fsImpl.putBucketLifecycle('test-expiration-lifecycle', prefix, days, cb);
-                    return cb.promise;
-                })).to.eventually.be.fulfilled;
+            return expect(function () {
+                var cb = cbQ.cb();
+                bucketS3fsImpl.putBucketLifecycle('test-lifecycle-callback', prefix, days, cb);
+                return cb.promise;
+                //TODO: Add verification that the lifecycle was set
+            }).to.eventually.be.fulfilled;
         });
 
         it('should be able to update a bucket lifecycle', function () {
@@ -89,13 +93,13 @@
                 initialDays = 1,
                 finalDays = 2;
 
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.putBucketLifecycle('test-expiration-lifecycle', prefix, initialDays)
-                        .then(function () {
-                            return s3fsImpl.putBucketLifecycle('test-expiration-lifecycle', prefix, finalDays);
-                        });
-                })).to.eventually.be.fulfilled;
+            return expect(function () {
+                return s3fsImpl.putBucketLifecycle('test-lifecycle-update', prefix, initialDays)
+                    .then(function () {
+                        return s3fsImpl.putBucketLifecycle('test-lifecycle-update', prefix, finalDays);
+                        //TODO: Add verification that the lifecycle was set
+                    });
+            }).to.eventually.be.fulfilled;
         });
 
         it('should be able to update a bucket lifecycle with a callback', function () {
@@ -103,15 +107,15 @@
                 initialDays = 1,
                 finalDays = 2;
 
-            return expect(s3fsImpl.create()
-                .then(function () {
-                    return s3fsImpl.putBucketLifecycle('test-expiration-lifecycle', prefix, initialDays)
-                        .then(function () {
-                            var cb = cbQ.cb();
-                            s3fsImpl.putBucketLifecycle('test-expiration-lifecycle', prefix, finalDays, cb);
-                            return cb.promise;
-                        });
-                })).to.eventually.be.fulfilled;
+            return expect(function () {
+                return s3fsImpl.putBucketLifecycle('test-lifecycle-update-callback', prefix, initialDays)
+                    .then(function () {
+                        var cb = cbQ.cb();
+                        s3fsImpl.putBucketLifecycle('test-lifecycle-update-callback', prefix, finalDays, cb);
+                        return cb.promise;
+                        //TODO: Add verification that the lifecycle was set
+                    });
+            }).to.eventually.be.fulfilled;
         });
 
     });

--- a/test/s3fs.js
+++ b/test/s3fs.js
@@ -28,7 +28,7 @@
     chai.use(chaiAsPromised);
     chai.config.includeStack = true;
 
-    describe.only('S3FS Instances', function () {
+    describe('S3FS Instances', function () {
         var s3Credentials,
             bucketName,
             bucketS3fsImpl,
@@ -43,7 +43,7 @@
                 secretAccessKey: process.env.AWS_SECRET_KEY,
                 region: process.env.AWS_REGION
             };
-            bucketName = 's3fs-test-bucket-' + (Math.random() + '').slice(2, 8);
+            bucketName = 's3fs-clone-test-bucket-' + (Math.random() + '').slice(2, 8);
             s3fsImpl = new S3FS(s3Credentials, bucketName);
 
             return s3fsImpl.create();


### PR DESCRIPTION
This PR updates our dependencies that were outdated and updates the tests to use less buckets in favor of more folders and the `clone()` functionality to reduce our usage of buckets. 

Additionally, this includes a fix to `rmdirp` and its usage of pre-pending the `S3FS` path to the files it was attempting to remove causing it to fail to delete them. Lastly, this includes an update to the `listObjects` method due to it not stripping off the prefixed path upon returning results.