### PR TITLE
Change copyObject to copyFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,18 @@ var fsImpl = new S3FS(options, 'test-bucket/test-folder');
 var fsImplStyles = fsImpl.clone('styles');
 ```
 
-### s3fs.copyObject(sourcePath, destinationPath, [cb])
-Allows an object to be copied from one path to another path within the same bucket. Paths are relative to
+### s3fs.copyFile(sourcePath, destinationPath, [cb])
+Allows a file to be copied from one path to another path within the same bucket. Paths are relative to
 the bucket originally provided.
 
-* sourcePath `String`. **Required**. Relative path to the source file
-* destinationPath `String`. **Required**. Relative path to the destination file
+* sourceFile `String`. **Required**. Relative path to the source file
+* destinationFile `String`. **Required**. Relative path to the destination file
 * cb `Function`. _Optional_. Callback to be used, if not provided will return a Promise
 
 ```js
 var fsImpl = new S3FS(options, 'test-bucket');
-fsImpl.copyObject('test-folder/test-file.txt', 'other-folder/test-file.txt').then(function() {
-  // Object was successfully copied
+fsImpl.copyFile('test-folder/test-file.txt', 'other-folder/test-file.txt').then(function() {
+  // File was successfully copied
 }, function(reason) {
   // Something went wrong
 });

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -213,43 +213,36 @@
     };
 
     /**
-     * Allows an object to be copied from one path to another path within the same bucket. Paths are relative to
+     * Allows a file to be copied from one path to another path within the same bucket. Paths are relative to
      * the bucket originally provided.
      *
      * @example
      * ```js
      * var fsImpl = new S3FS(options, 'test-bucket');
-     * fsImpl.copyObject('test-folder/test-file.txt', 'other-folder/test-file.txt').then(function() {
+     * fsImpl.copyFile('test-folder/test-file.txt', 'other-folder/test-file.txt').then(function() {
      *   // Object was successfully copied
      * }, function(reason) {
      *   // Something went wrong
      * });
      * ```
      *
-     * @param sourcePath `String`. **Required**. Relative path to the source file
-     * @param destinationPath `String`. **Required**. Relative path to the destination file
+     * @param sourceFile `String`. **Required**. Relative path to the source file
+     * @param destinationFile `String`. **Required**. Relative path to the destination file
      * @param cb `Function`. _Optional_. Callback to be used, if not provided will return a Promise
      * @returns {Promise|*} Returns a `Promise` if a callback is not provided
      */
-    S3fs.prototype.copyObject = function (sourcePath, destinationPath, cb) {
+    S3fs.prototype.copyFile = function (sourceFile, destinationFile, cb) {
         var deferred = !cb ? q.defer() : undefined;
-        if (directoryRegExp.test(sourcePath)) {
-            // Directories are automatically created, so there's no need to 'copy' a directory.
-            process.nextTick(function () {
-                return deferred ? deferred.resolve() : cb(null);
-            });
-        } else {
-            this.s3.copyObject({
-                Bucket: this.bucket,
-                Key: this.path + s3Utils.toKey(destinationPath),
-                CopySource: [this.bucket, this.path + s3Utils.toKey(sourcePath)].join('/')
-            }, function (err) {
-                if (err) {
-                    return deferred ? deferred.reject(err + sourcePath) : cb(err + sourcePath);
-                }
-                return deferred ? deferred.resolve() : cb(null);
-            });
-        }
+        this.s3.copyObject({
+            Bucket: this.bucket,
+            Key: this.path + s3Utils.toKey(destinationFile),
+            CopySource: [this.bucket, this.path + s3Utils.toKey(sourceFile)].join('/')
+        }, function (err) {
+            if (err) {
+                return deferred ? deferred.reject(err + sourceFile) : cb(err + sourceFile);
+            }
+            return deferred ? deferred.resolve() : cb(null);
+        });
         return deferred ? deferred.promise : undefined;
     };
 
@@ -410,7 +403,7 @@
                 process.nextTick(function () {
                     var promises = [];
                     files.forEach(function (file) {
-                        promises.push(self.copyObject([s3Utils.toKey(sourcePath), file].join('/'), [s3Utils.toKey(destinationPath), file].join('/')));
+                        promises.push(self.copyFile([s3Utils.toKey(sourcePath), file].join('/'), [s3Utils.toKey(destinationPath), file].join('/')));
                     });
                     q.all(promises).then(function () {
                         deferred.resolve();

--- a/test/file.js
+++ b/test/file.js
@@ -112,7 +112,7 @@
         it('should be able to copy an object', function () {
             return expect(bucketS3fsImpl.writeFile('test-copy.json', '{}')
                     .then(function () {
-                        return bucketS3fsImpl.copyObject('test-copy.json', 'test-copy-dos.json');
+                        return bucketS3fsImpl.copyFile('test-copy.json', 'test-copy-dos.json');
                     })
             ).to.eventually.be.fulfilled();
         });
@@ -121,7 +121,7 @@
             return expect(bucketS3fsImpl.writeFile('test-copy-callback.json', '{}')
                     .then(function () {
                         var cb = cbQ.cb();
-                        bucketS3fsImpl.copyObject('test-copy-callback.json', 'test-copy-callback-dos.json', cb);
+                        bucketS3fsImpl.copyFile('test-copy-callback.json', 'test-copy-callback-dos.json', cb);
                         return cb.promise;
                     })
             ).to.eventually.be.fulfilled();


### PR DESCRIPTION
This PR is part of the normalization of our API. It normalizes our `copyFile()` call with that of our [mixins](https://github.com/RiptideCloud/node-fs-wishlist).