### PR TITLE
Change copyDirectory to copyDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ fsImpl.copyObject('test-folder/test-file.txt', 'other-folder/test-file.txt').the
 });
 ```
 
-### s3fs.copyDirectory(sourcePath, destinationPath, [cb])
+### s3fs.copyDir(sourcePath, destinationPath, [cb])
 Recursively copies a directory from the source path to the destination path.
 
 * sourcePath `String`. **Required**. The source directory to be copied

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -391,7 +391,7 @@
      * @example
      * ```js
      * var fsImpl = new S3FS(options, 'test-bucket');
-     * fsImpl.copyDirectory('test-folder', 'other-folder').then(function() {
+     * fsImpl.copyDir('test-folder', 'other-folder').then(function() {
      *   // Directory was successfully copied
      * }, function(reason) {
      *   // Something went wrong
@@ -403,7 +403,7 @@
      * @param cb `Function`. _Optional_. Callback to be used, if not provided will return a Promise
      * @returns {Promise|*} Returns a `Promise` if a callback is not provided
      */
-    S3fs.prototype.copyDirectory = function (sourcePath, destinationPath, cb) {
+    S3fs.prototype.copyDir = function (sourcePath, destinationPath, cb) {
         var self = this,
             promise = listAllObjectsFiles(this.s3, this.bucket, this.path + s3Utils.toKey(sourcePath) + '/').then(function (files) {
                 var deferred = q.defer();

--- a/test/directory.js
+++ b/test/directory.js
@@ -156,7 +156,7 @@
                         return bucketS3fsImpl.writeFile('testDir/test/test.json', '{}');
                     })
                     .then(function () {
-                        return bucketS3fsImpl.copyDirectory('testDir', 'testCopyDirDestPromise');
+                        return bucketS3fsImpl.copyDir('testDir', 'testCopyDirDestPromise');
                     })
                     .then(function () {
                         return bucketS3fsImpl.readdir('testCopyDirDestPromise');
@@ -175,7 +175,7 @@
                         return bucketS3fsImpl.writeFile('testDir/test/test.json', '{}');
                     })
                     .then(function () {
-                        return bucketS3fsImpl.copyDirectory('testDir', 'testCopyDirDestCb');
+                        return bucketS3fsImpl.copyDir('testDir', 'testCopyDirDestCb');
                     })
                     .then(function () {
                         var cb = cbQ.cb();


### PR DESCRIPTION
This PR is part of the normalization of our API. It normalizes our `copyDirectory()` call with that of our [mixins](https://github.com/RiptideCloud/node-fs-wishlist).