### PR TITLE
Add making directory recrusively

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,21 @@ fsImpl.readdirp('test-folder').then(function(files) {
 });
 ```
 
+### s3fs.mkdirp(path, [cb])
+Recursively creates a directory.
+
+* path The path to the directory to create
+* cb `Function`. _Optional_. Callback to be used, if not provided will return a Promise
+
+```js
+var fsImpl = new S3FS(options, 'test-bucket');
+fsImpl.mkdirp('test-folder').then(function() {
+  // Directory has been recursively created
+}, function(reason) {
+  // Something went wrong
+});
+```
+
 ### s3fs.rmdirp(path, [cb])
 Recursively deletes a directory.
 

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -99,7 +99,7 @@
         return deferred ? deferred.promise : undefined;
     };
 
-    function mkdir(path, cb) {
+    S3fs.prototype.mkdir = function mkdir(path, cb) {
         var promise = putObject(this.s3, this.bucket, this.path + s3Utils.toKey(path) + '/');
         if (!cb) {
             return promise;
@@ -109,11 +109,9 @@
         }, function (reason) {
             cb(reason);
         });
-    }
+    };
 
-    S3fs.prototype.mkdir = mkdir;
-
-    S3fs.prototype.mkdirp = mkdir;
+    S3fs.prototype.mkdirp = S3fs.prototype.mkdir;
 
     S3fs.prototype.stat = function (path, cb) {
         return getFileStats(this, path, cb);

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -99,7 +99,7 @@
         return deferred ? deferred.promise : undefined;
     };
 
-    S3fs.prototype.mkdir = function (path, cb) {
+    function mkdir(path, cb) {
         var promise = putObject(this.s3, this.bucket, this.path + s3Utils.toKey(path) + '/');
         if (!cb) {
             return promise;
@@ -109,7 +109,11 @@
         }, function (reason) {
             cb(reason);
         });
-    };
+    }
+
+    S3fs.prototype.mkdir = mkdir;
+
+    S3fs.prototype.mkdirp = mkdir;
 
     S3fs.prototype.stat = function (path, cb) {
         return getFileStats(this, path, cb);

--- a/test/directory.js
+++ b/test/directory.js
@@ -77,6 +77,16 @@
             return expect(cb.promise).to.eventually.be.fulfilled;
         });
 
+        it('should be able to recursively create directories', function () {
+            return expect(bucketS3fsImpl.mkdirp('testDir/testSubDir/anotherDir')).to.eventually.be.fulfilled;
+        });
+
+        it('should be able to recursively create directories with a callback', function () {
+            var cb = cbQ.cb();
+            bucketS3fsImpl.mkdirp('testDirDos/testSubDir/anotherDir', cb);
+            return expect(cb.promise).to.eventually.be.fulfilled;
+        });
+
         it('should be able to tell that a directory exists', function () {
             return expect(bucketS3fsImpl.exists('/')).to.eventually.be.fulfilled;
         });


### PR DESCRIPTION
Added the ability to create directories recursively. S3, doesn't care about parent directories existing so this is literally just the same call as `mkdir`.