### PR TITLE
Add handling for encoding to Read and Write file

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -179,6 +179,8 @@
             options = undefined;
         }
 
+        options = options || {};
+
         if (options.encoding) {
             options.ResponseContentEncoding = options.encoding;
             delete options.encoding;
@@ -230,6 +232,8 @@
             callback = options;
             options = undefined;
         }
+
+        options = options || {};
 
         if (options.encoding) {
             options.ContentEncoding = options.encoding;

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -173,19 +173,18 @@
         });
     };
 
-    S3fs.prototype.readFile = function (name, callback) {
-        var self = this;
-        var promise = new Promise(function (resolve, reject) {
-            self.s3.getObject({
-                Bucket: self.bucket,
-                Key: self.path + s3Utils.toKey(name, self.bucket, self.path)
-            }, function (err, data) {
-                if (err) {
-                    return reject(err);
-                }
-                return resolve(data);
-            });
-        });
+    S3fs.prototype.readFile = function (name, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = undefined;
+        }
+
+        if (options.encoding) {
+            options.ResponseContentEncoding = options.encoding;
+            delete options.encoding;
+        }
+
+        var promise = getObject(this.s3, this.bucket, this.path + s3Utils.toKey(name, this.bucket, this.path), options);
 
         if (!callback) {
             return promise;
@@ -230,6 +229,11 @@
         if (typeof options === 'function') {
             callback = options;
             options = undefined;
+        }
+
+        if (options.encoding) {
+            options.ContentEncoding = options.encoding;
+            delete options.encoding;
         }
 
         var promise = putObject(this.s3, this.bucket, this.path + s3Utils.toKey(name), data, options);
@@ -824,12 +828,27 @@
         });
     }
 
+    function getObject(s3, bucket, key, options) {
+        var s3Options = extend(typeof options === 'object' ? options : {}, {
+            Bucket: bucket,
+            Key: key
+        });
+        return new Promise(function (resolve, reject) {
+            s3.getObject(s3Options, function (err, data) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(data);
+            });
+        });
+    }
+
     function putObject(s3, bucket, key, body, options) {
         var s3Options = extend(typeof options === 'object' ? options : {}, {
             Bucket: bucket,
             Key: key,
             Body: body
-        }); // S3 Put Options: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/frames.html
+        });
         return new Promise(function (resolve, reject) {
             s3.putObject(s3Options, function (err, data) {
                 if (err) {

--- a/test/file.js
+++ b/test/file.js
@@ -86,7 +86,7 @@
             return expect(bucketS3fsImpl.writeFile('write-large.txt', largeFile)).to.eventually.be.fulfilled();
         });
 
-        it.only('should be able to write a file with encoding', function () {
+        it('should be able to write a file with encoding', function () {
             var fileText = '{ "test": "test" }';
             var options = {encoding: 'utf16'};
             return bucketS3fsImpl.writeFile('test-file.json', fileText, {encoding: 'utf16'}).then(function () {

--- a/test/file.js
+++ b/test/file.js
@@ -86,6 +86,17 @@
             return expect(bucketS3fsImpl.writeFile('write-large.txt', largeFile)).to.eventually.be.fulfilled();
         });
 
+        it.only('should be able to write a file with encoding', function () {
+            var fileText = '{ "test": "test" }';
+            var options = {encoding: 'utf16'};
+            return bucketS3fsImpl.writeFile('test-file.json', fileText, {encoding: 'utf16'}).then(function () {
+                return expect(bucketS3fsImpl.readFile('test-file.json', options)).to.eventually.satisfy(function (data) {
+                    expect(data.Body.toString()).to.equal(fileText);
+                    return true;
+                });
+            });
+        });
+
         it('should be able to write a large file with a callback', function () {
             var largeFile = fs.readFileSync('./test/mock/large-file.txt');
             return expect(new Promise(function (resolve, reject) {


### PR DESCRIPTION
This PR adds the ability to pass the encoding when using `fs.readFile()` and `fs.writeFile()` and properly maps the values to what S3 expects them to be.