### PR TITLE
Swap Bucket and Options in the Constructor

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -37,6 +37,10 @@
             throw new Error('bucket is required');
         }
 
+        if (typeof bucket !== 'string') {
+            throw new Error('bucket must be a string');
+        }
+
         var bucketParts = s3Utils.decomposePath(bucket);
         this.s3 = options instanceof AWS.S3 ? options : new AWS.S3(options);
         this.bucket = bucketParts[0];

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -28,19 +28,9 @@
     var directoryRegExp = /\/$/,
         defaultCreateOptions = {};
 
-    function S3fs(options, bucket) {
+    function S3fs(bucket, options) {
         if (!(this instanceof S3fs)) {
-            return new S3fs(options, bucket);
-        }
-
-        if (!options) {
-            throw new Error('options is required');
-        } else if (!(options instanceof AWS.S3)) {
-            if (!options.accessKeyId) {
-                throw new Error('accessKeyId is required');
-            } else if (!options.secretAccessKey) {
-                throw new Error('secretAccessKey is required');
-            }
+            return new S3fs(bucket, options);
         }
 
         if (!bucket) {
@@ -268,7 +258,7 @@
      * @returns {S3fs}
      */
     S3fs.prototype.clone = function (path) {
-        return new S3fs(this.s3, s3Utils.joinPaths(this.bucket, s3Utils.joinPaths(this.path, path)));
+        return new S3fs(s3Utils.joinPaths(this.bucket, s3Utils.joinPaths(this.path, path)), this.s3);
     };
 
     /**

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -46,7 +46,7 @@
                 region: process.env.AWS_REGION
             };
             bucketName = 's3fs-bucket-test-bucket-' + (Math.random() + '').slice(2, 8);
-            s3fsImpl = new S3FS(s3Credentials, bucketName);
+            s3fsImpl = new S3FS(bucketName, s3Credentials);
         });
 
         afterEach(function (done) {
@@ -78,7 +78,7 @@
             // See: http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
             //TODO: Even though this is an invalid bucketname the AWS SDK still lets you create it.
             var bucketMaxLength = 64;
-            s3fsImpl = new S3FS(s3Credentials, new Array(bucketMaxLength).join('asdf'));
+            s3fsImpl = new S3FS(new Array(bucketMaxLength).join('asdf'), s3Credentials);
             return expect(s3fsImpl.create()).to.eventually.be.rejectedWith('asdf');
         });
 

--- a/test/directory.js
+++ b/test/directory.js
@@ -45,7 +45,7 @@
                 region: process.env.AWS_REGION
             };
             bucketName = 's3fs-directory-test-bucket-' + (Math.random() + '').slice(2, 8);
-            s3fsImpl = new S3FS(s3Credentials, bucketName);
+            s3fsImpl = new S3FS(bucketName, s3Credentials);
 
             return s3fsImpl.create();
         });

--- a/test/file.js
+++ b/test/file.js
@@ -44,7 +44,7 @@
                 region: process.env.AWS_REGION
             };
             bucketName = 's3fs-file-test-bucket-' + (Math.random() + '').slice(2, 8);
-            s3fsImpl = new S3FS(s3Credentials, bucketName);
+            s3fsImpl = new S3FS(bucketName, s3Credentials);
 
             return s3fsImpl.create();
         });

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -44,7 +44,7 @@
                 region: process.env.AWS_REGION
             };
             bucketName = 's3fs-lifecycle-test-bucket-' + (Math.random() + '').slice(2, 8);
-            s3fsImpl = new S3FS(s3Credentials, bucketName);
+            s3fsImpl = new S3FS(bucketName, s3Credentials);
 
             return s3fsImpl.create();
         });

--- a/test/s3fs.js
+++ b/test/s3fs.js
@@ -44,7 +44,7 @@
                 region: process.env.AWS_REGION
             };
             bucketName = 's3fs-clone-test-bucket-' + (Math.random() + '').slice(2, 8);
-            s3fsImpl = new S3FS(s3Credentials, bucketName);
+            s3fsImpl = new S3FS(bucketName, s3Credentials);
 
             return s3fsImpl.create();
         });

--- a/test/s3fs.js
+++ b/test/s3fs.js
@@ -66,27 +66,33 @@
             });
         });
 
-        it('shouldn\'t be able to instaniate S3FS without a bucket', function () {
+        it('shouldn\'t be able to instantiate S3FS without a bucket', function () {
             return expect(function () {
                 S3FS();
             }).to.throw(Error, 'bucket is required');
         });
 
-        it('should be able to instaniate S3FS without options', function () {
+        it('shouldn\'t be able to instantiate S3FS with an invalid bucket', function () {
+            return expect(function () {
+                S3FS({});
+            }).to.throw(Error, 'bucket must be a string');
+        });
+
+        it('should be able to instantiate S3FS without options', function () {
             return expect(function () {
                 S3FS('bucket');
             }).to.not.throw();
         });
 
-        it('shouldn\'t be able to instaniate S3FS without an accessKeyId', function () {
+        it('shouldn\'t be able to instantiate S3FS without an accessKeyId', function () {
             return expect(function () {
-                S3FS({});
+                S3FS('bucket', {});
             }).to.not.throw();
         });
 
-        it('shouldn\'t be able to instaniate S3FS without a secretAccessKey', function () {
+        it('shouldn\'t be able to instantiate S3FS without a secretAccessKey', function () {
             return expect(function () {
-                S3FS({accessKeyId: 'test'});
+                S3FS('bucket', {accessKeyId: 'test'});
             }).to.not.throw();
         });
 

--- a/test/s3fs.js
+++ b/test/s3fs.js
@@ -66,28 +66,28 @@
             });
         });
 
-        it('shouldn\'t be able to instaniate S3FS without options', function () {
+        it('shouldn\'t be able to instaniate S3FS without a bucket', function () {
             return expect(function () {
                 S3FS();
-            }).to.throw(Error, 'options is required');
+            }).to.throw(Error, 'bucket is required');
+        });
+
+        it('should be able to instaniate S3FS without options', function () {
+            return expect(function () {
+                S3FS('bucket');
+            }).to.not.throw();
         });
 
         it('shouldn\'t be able to instaniate S3FS without an accessKeyId', function () {
             return expect(function () {
                 S3FS({});
-            }).to.throw(Error, 'accessKeyId is required');
+            }).to.not.throw();
         });
 
         it('shouldn\'t be able to instaniate S3FS without a secretAccessKey', function () {
             return expect(function () {
                 S3FS({accessKeyId: 'test'});
-            }).to.throw(Error, 'secretAccessKey is required');
-        });
-
-        it('shouldn\'t be able to instaniate S3FS without a bucket', function () {
-            return expect(function () {
-                S3FS({accessKeyId: 'test', secretAccessKey: 'test'});
-            }).to.throw(Error, 'bucket is required');
+            }).to.not.throw();
         });
 
         it('should be able to clone s3fs', function () {


### PR DESCRIPTION
This PR covers #8 and swaps the position of Bucket and Options in the constructor for S3FS so that the options are optional since the AWS SDK can pick the credentials up in a few different ways other than by them being directly passed to it.