### PR TITLE
Fix Destroying Bucket From Subfolder

### DIFF
--- a/lib/s3WriteStream.js
+++ b/lib/s3WriteStream.js
@@ -173,7 +173,7 @@
     };
 
     function S3WriteStream(client, bucket, key, options) {
-        if (!this instanceof S3WriteStream) {
+        if (!(this instanceof S3WriteStream)) {
             return new S3WriteStream(client, bucket, key, options);
         }
         this.multiPartManager = new MultiPartManager(client, bucket, key);

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -653,12 +653,12 @@
                     return !directoryRegExp.test(object);
                 }).map(function (object) {
                     //remove all the items
-                    return self.unlink((path ? s3Utils.toKey(path) + '/' : '') + object);
+                    return deleteObject(self.s3, self.bucket, (path ? s3Utils.toKey(path) + '/' : '') + object);
                 }).concat(objects.filter(function (object) {
                     return directoryRegExp.test(object);
                 }).map(function (object) {
                     //remove all folders
-                    return self.rmdir((path ? s3Utils.toKey(path) + '/' : '') + object);
+                    return deleteObject(self.s3, self.bucket, (path ? s3Utils.toKey(path) + '/' : '') + object);
                 })));
             });
 

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -544,9 +544,26 @@
      */
     S3fs.prototype.destroy = function (callback) {
         var self = this;
-        var promise = self.rmdirp().then(function () {
-            return self.delete();
-        });
+        var promise = self.rmdirp()
+            .then(function () {
+                return listAllObjectsFiles(self.s3, self.bucket).then(function (objects) {
+                    return Promise.all(objects.filter(function (object) {
+                        //filter items
+                        return !directoryRegExp.test(object);
+                    }).map(function (object) {
+                        //remove all the objects
+                        return deleteObject(self.s3, self.bucket, object);
+                    }).concat(objects.filter(function (object) {
+                        return directoryRegExp.test(object);
+                    }).map(function (object) {
+                        //remove all folders
+                        return deleteObject(self.s3, self.bucket, object);
+                    })));
+                });
+            })
+            .then(function () {
+                return self.delete();
+            });
 
         if (!callback) {
             return promise;
@@ -653,12 +670,12 @@
                     return !directoryRegExp.test(object);
                 }).map(function (object) {
                     //remove all the items
-                    return deleteObject(self.s3, self.bucket, (path ? s3Utils.toKey(path) + '/' : '') + object);
+                    return self.unlink((path ? s3Utils.toKey(path) + '/' : '') + object);
                 }).concat(objects.filter(function (object) {
                     return directoryRegExp.test(object);
                 }).map(function (object) {
                     //remove all folders
-                    return deleteObject(self.s3, self.bucket, (path ? s3Utils.toKey(path) + '/' : '') + object);
+                    return self.rmdir((path ? s3Utils.toKey(path) + '/' : '') + object);
                 })));
             });
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "jsinspect": "^0.x"
   },
   "scripts": {
-    "test": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks  --timeout 60000 --reporter nyan test/ && jshint --show-non-errors . && jscs . && buddy index.js lib test && nsp audit-package"
+    "test": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks  --timeout 60000 --reporter spec test/ && jshint --show-non-errors . && jscs . && buddy index.js lib test && nsp audit-package"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3fs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Implementation of Node.JS FS interface using Amazon Simple Storage Service (S3).",
   "keywords": [
     "s3fs",

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -167,13 +167,13 @@
 
         it('should be able to destroy bucket with contents in it', function () {
             return expect(s3fsImpl.create()
-                .then(function() {
+                .then(function () {
                     return s3fsImpl.writeFile('test.json', 'test');
                 })
-                .then(function() {
+                .then(function () {
                     return s3fsImpl.writeFile('some/folder.json', 'test');
                 })
-                .then(function() {
+                .then(function () {
                     return s3fsImpl.writeFile('some/highly/nested/object/in/folder/which/is/highly/nested.json', 'test');
                 })
                 .then(function () {
@@ -183,14 +183,14 @@
 
         it('should be able to destroy bucket with contents in it from a sub-folder', function () {
             return expect(s3fsImpl.create()
-                .then(function() {
+                .then(function () {
                     s3fsImpl = s3fsImpl.clone('sub/folder');
                     return s3fsImpl.writeFile('test.json', 'test');
                 })
-                .then(function() {
+                .then(function () {
                     return s3fsImpl.writeFile('some/folder.json', 'test');
                 })
-                .then(function() {
+                .then(function () {
                     return s3fsImpl.writeFile('some/highly/nested/object/in/folder/which/is/highly/nested.json', 'test');
                 })
                 .then(function () {

--- a/test/bucket.js
+++ b/test/bucket.js
@@ -165,6 +165,39 @@
                 })).to.eventually.be.fulfilled();
         });
 
+        it('should be able to destroy bucket with contents in it', function () {
+            return expect(s3fsImpl.create()
+                .then(function() {
+                    return s3fsImpl.writeFile('test.json', 'test');
+                })
+                .then(function() {
+                    return s3fsImpl.writeFile('some/folder.json', 'test');
+                })
+                .then(function() {
+                    return s3fsImpl.writeFile('some/highly/nested/object/in/folder/which/is/highly/nested.json', 'test');
+                })
+                .then(function () {
+                    return s3fsImpl.destroy();
+                })).to.eventually.be.fulfilled();
+        });
+
+        it('should be able to destroy bucket with contents in it from a sub-folder', function () {
+            return expect(s3fsImpl.create()
+                .then(function() {
+                    s3fsImpl = s3fsImpl.clone('sub/folder');
+                    return s3fsImpl.writeFile('test.json', 'test');
+                })
+                .then(function() {
+                    return s3fsImpl.writeFile('some/folder.json', 'test');
+                })
+                .then(function() {
+                    return s3fsImpl.writeFile('some/highly/nested/object/in/folder/which/is/highly/nested.json', 'test');
+                })
+                .then(function () {
+                    return s3fsImpl.destroy();
+                })).to.eventually.be.fulfilled();
+        });
+
         it('should be able to destroy bucket with a callback', function () {
             return expect(s3fsImpl.create()
                 .then(function () {


### PR DESCRIPTION
This PR fixes the `rmdirp` function which is used for removing directories both from the normal context and from the context of destroying a bucket. The issue occurred when creating a bucket with a path already in it: ie. `mybucket/some/folder` which was not able to remove the items in the subfolder due to a bug in the handling of `rmdirp` which used `unlink()` causing it to append the original path and resulted in an incorrectly nested path for the delete.