### PR TITLE
Add node 0.12 and iojs to the build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 sudo: false
 node_js:
-- 0.10.31
 - '0.10'
 - '0.11'
+- '0.12'
+- 'iojs'
 env:
   global:
   - LOG_LEVEL=error
@@ -21,3 +22,4 @@ deploy:
   on:
     tags: true
     repo: RiptideCloud/s3fs
+    node: 0.12


### PR DESCRIPTION
This PR adds Node 0.12 and iojs to the build targets to test compatibility. Additionally, it adds a clarification to the deployment on tags so that it only deploys once.